### PR TITLE
[ntpcheck] support serverstats with ntpd 4.2.8+

### DIFF
--- a/ntpcheck/checker/chrony.go
+++ b/ntpcheck/checker/chrony.go
@@ -76,10 +76,7 @@ func (n *ChronyCheck) Run() (*NTPCheckResult, error) {
 		if !ok {
 			return nil, errors.Errorf("Got wrong 'serverstats' response %+v", packet)
 		}
-		result.ServerStats = &ServerStats{
-			PacketsReceived: uint64(stats.NTPHits),
-			PacketsDropped:  uint64(stats.NTPDrops),
-		}
+		result.ServerStats = NewServerStatsFromChrony(stats)
 		log.Debugf("ServerStats: %v", result.ServerStats)
 	} else if err != chrony.ErrNotAuthorized {
 		return nil, errors.Wrap(err, "failed to get 'serverstats' response")

--- a/ntpcheck/checker/serverstats.go
+++ b/ntpcheck/checker/serverstats.go
@@ -1,0 +1,65 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package checker
+
+import (
+	"strconv"
+
+	"github.com/facebookincubator/ntp/protocol/chrony"
+	"github.com/facebookincubator/ntp/protocol/control"
+)
+
+// various counters for dropped packets
+var droppedVars = []string{"ss_badformat", "ss_badauth", "ss_declined", "ss_restricted", "ss_limited"}
+
+// ServerStats holds NTP server operational stats
+type ServerStats struct {
+	PacketsReceived uint64 `json:"ntp.server.packets_received"`
+	PacketsDropped  uint64 `json:"ntp.server.packets_dropped"`
+}
+
+// NewServerStatsFromNTP constructs ServerStats from NTPControlMsg packet
+func NewServerStatsFromNTP(p *control.NTPControlMsg) (*ServerStats, error) {
+	data, err := control.NormalizeData(p.Data)
+	if err != nil {
+		return nil, err
+	}
+	received, err := strconv.ParseUint(data["ss_received"], 10, 64)
+	if err != nil {
+		return nil, err
+	}
+	var dropped uint64
+	for _, varName := range droppedVars {
+		v, err := strconv.ParseUint(data[varName], 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		dropped += v
+	}
+	return &ServerStats{
+		PacketsReceived: received,
+		PacketsDropped:  dropped,
+	}, nil
+}
+
+// NewServerStatsFromChrony constructs ServerStats from chrony ServerStats packet
+func NewServerStatsFromChrony(s *chrony.ReplyServerStats) *ServerStats {
+	return &ServerStats{
+		PacketsReceived: uint64(s.NTPHits),
+		PacketsDropped:  uint64(s.NTPDrops),
+	}
+}

--- a/ntpcheck/checker/system.go
+++ b/ntpcheck/checker/system.go
@@ -23,12 +23,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-// ServerStats holds NTP server operational stats
-type ServerStats struct {
-	PacketsReceived uint64 `json:"ntp.server.packets_received"`
-	PacketsDropped  uint64 `json:"ntp.server.packets_dropped"`
-}
-
 // SystemVariables holds System Variables extracted from k=v pairs, as described in http://doc.ntp.org/current-stable/ntpq.html
 type SystemVariables struct {
 	Version   string

--- a/ntpcheck/cmd/serverstats.go
+++ b/ntpcheck/cmd/serverstats.go
@@ -22,12 +22,13 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
 	"github.com/facebookincubator/ntp/ntpcheck/checker"
 )
 
 func printServerStats(r *checker.NTPCheckResult) error {
 	if r.ServerStats == nil {
-		return fmt.Errorf("no server stats present (only chrony over unix socket is currently supported)")
+		return fmt.Errorf("no server stats present (chrony is supported only over unix socket, required ntpd version 4.2.8+)")
 	}
 	toPrint, err := json.Marshal(r.ServerStats)
 	if err != nil {

--- a/ntpcheck/cmd/stats.go
+++ b/ntpcheck/cmd/stats.go
@@ -23,6 +23,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
 	"github.com/facebookincubator/ntp/ntpcheck/checker"
 )
 


### PR DESCRIPTION
## Summary

Now we support server stats on ntpd just as well.

## Test Plan

Ran the code on host with ntpd:
```
abulimov@u1804:~/go/src/github.com/facebookincubator/ntp/ntpcheck$ ./ntpcheck serverstats
{"ntp.server.packets_received":1966,"ntp.server.packets_dropped":24}
```

and chrony:
```
[root@chronyhost ~]# ./ntpchkng serverstats
{"ntp.server.packets_received":2875803805,"ntp.server.packets_dropped":0}
```