### PR TITLE
Make ntpcheck work over ipv4 (fixes #25)

### DIFF
--- a/ntpcheck/checker/runner.go
+++ b/ntpcheck/checker/runner.go
@@ -123,7 +123,7 @@ func RunCheck(address string) (*NTPCheckResult, error) {
 			return nil, err
 		}
 	} else {
-		conn, err = net.DialTimeout("udp6", address, timeout)
+		conn, err = net.DialTimeout("udp", address, timeout)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary
One-line fix to support ipv4 addresses

## Test Plan
works with both v4 and v6 now:
```
abulimov@u1804:~/go/src/github.com/facebookincubator/ntp/ntpcheck$ ./ntpcheck stats -S 127.0.0.1:123
{"ntp.peer.delay":41.308,"ntp.peer.poll":128,"ntp.peer.jitter":4.277,"ntp.peer.offset":-1.187,"ntp.peer.stratum":2,"ntp.sys.frequency":13.911,"ntp.stat.error":false}
abulimov@u1804:~/go/src/github.com/facebookincubator/ntp/ntpcheck$ ./ntpcheck stats -S '[::1]:123'
{"ntp.peer.delay":41.308,"ntp.peer.poll":128,"ntp.peer.jitter":4.277,"ntp.peer.offset":-1.187,"ntp.peer.stratum":2,"ntp.sys.frequency":13.911,"ntp.stat.error":false}
```
