### PR TITLE
Remove hardware timestamps reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ go get github.com/facebookincubator/ntp/ntpcheck
 ```
 
 ## Responder
-Simple NTP server implementation with hardware timestamps support
+Simple NTP server implementation with kernel timestamps support
 
 ### Quick Installation
 ```console

--- a/ntpcheck/cmd/utils.go
+++ b/ntpcheck/cmd/utils.go
@@ -111,7 +111,7 @@ func ntpDate(remoteServerAddr string, remoteServerPort string, requests int) err
 	}
 	defer conn.Close()
 
-	// Allow reading of hardware/kernel timestamps via socket
+	// Allow reading of kernel timestamps via socket
 	if err := ntp.EnableKernelTimestampsSocket(conn.(*net.UDPConn)); err != nil {
 		return err
 	}

--- a/protocol/ntp/ntp_test.go
+++ b/protocol/ntp/ntp_test.go
@@ -254,7 +254,7 @@ func Test_ReadPacketWithKernelTimestamp(t *testing.T) {
 	assert.Nil(t, err)
 	defer conn.Close()
 
-	// Allow reading of hardware/kernel timestamps via socket
+	// Allow reading of kernel timestamps via socket
 	err = EnableKernelTimestampsSocket(conn)
 	assert.Nil(t, err)
 
@@ -266,10 +266,10 @@ func Test_ReadPacketWithKernelTimestamp(t *testing.T) {
 	_, err = cconn.Write(ntpRequestBytes)
 	assert.Nil(t, err)
 
-	// read HW/kernel timestamp from incoming packet
-	request, nowHWtimestamp, returnaddr, err := ReadPacketWithKernelTimestamp(conn)
+	// read kernel timestamp from incoming packet
+	request, nowKernelTimestamp, returnaddr, err := ReadPacketWithKernelTimestamp(conn)
 	assert.Equal(t, ntpRequest, request, "We should have the same request arriving on the server")
-	assert.Equal(t, time.Now().Unix()/10, nowHWtimestamp.Unix()/10, "hwtimestamps should be within 10s")
+	assert.Equal(t, time.Now().Unix()/10, nowKernelTimestamp.Unix()/10, "kernel timestamps should be within 10s")
 	assert.Equal(t, cconn.LocalAddr().String(), returnaddr.String())
 	assert.Nil(t, err)
 }
@@ -287,19 +287,19 @@ func Benchmark_BytesToPacketConversion(b *testing.B) {
 }
 
 /*
-Benchmark_ServerWithoutHWTimestamps is a benchmark to determine speed of
-reading NTP packets without hardware timestamps
+Benchmark_ServerWithoutKernelTimestamps is a benchmark to determine speed of
+reading NTP packets without kernel timestamps
 Usually numbers look like:
 
-~/go/src/github.com/facebookincubator/ntp/protocol/ntp go test -bench=ServerWithoutHWTimestamps
+~/go/src/github.com/facebookincubator/ntp/protocol/ntp go test -bench=ServerWithoutKernelTimestamps
 goos: linux
 goarch: amd64
 pkg: github.com/facebookincubator/ntp/protocol/ntp
-Benchmark_ServerWithoutHWTimestamps-24    	  204441	      4997 ns/op
+Benchmark_ServerWithoutKernelTimestamps-24    	  204441	      4997 ns/op
 PASS
 ok  	github.com/facebookincubator/ntp/protocol/ntp	1.094s
 */
-func Benchmark_ServerWithoutHWTimestamps(b *testing.B) {
+func Benchmark_ServerWithoutKernelTimestamps(b *testing.B) {
 	// Server
 	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("localhost"), Port: 0})
 	assert.Nil(b, err)
@@ -318,13 +318,13 @@ func Benchmark_ServerWithoutHWTimestamps(b *testing.B) {
 	}
 }
 
-func Benchmark_ServerWithHWTimestamps(b *testing.B) {
+func Benchmark_ServerWithKernelTimestamps(b *testing.B) {
 	// Server
 	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("localhost"), Port: 0})
 	assert.Nil(b, err)
 	defer conn.Close()
 
-	// Allow reading of hardware/kernel timestamps via socket
+	// Allow reading of kernel timestamps via socket
 	err = EnableKernelTimestampsSocket(conn)
 	assert.Nil(b, err)
 
@@ -342,25 +342,25 @@ func Benchmark_ServerWithHWTimestamps(b *testing.B) {
 }
 
 /*
-Benchmark_ServerWithHWTimestampsRead is a benchmark to determine speed of
-reading NTP packets with hardware timestamps
+Benchmark_ServerWithKernelTimestampsRead is a benchmark to determine speed of
+reading NTP packets with kernel timestamps
 Usually numbers look like:
 
-~/go/src/github.com/facebookincubator/ntp/protocol/ntp go test -bench=ServerWithHWTimestampsRead
+~/go/src/github.com/facebookincubator/ntp/protocol/ntp go test -bench=ServerWithKernelTimestampsRead
 goos: linux
 goarch: amd64
 pkg: github.com/facebookincubator/ntp/protocol/ntp
-Benchmark_ServerWithHWTimestampsRead-24    	  143074	      8084 ns/op
+Benchmark_ServerWithKernelTimestampsRead-24    	  143074	      8084 ns/op
 PASS
 ok  	github.com/facebookincubator/ntp/protocol/ntp	1.778s
 */
-func Benchmark_ServerWithHWTimestampsRead(b *testing.B) {
+func Benchmark_ServerWithKernelTimestampsRead(b *testing.B) {
 	// Server
 	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("localhost"), Port: 0})
 	assert.Nil(b, err)
 	defer conn.Close()
 
-	// Allow reading of hardware/kernel timestamps via socket
+	// Allow reading of kernel timestamps via socket
 	err = EnableKernelTimestampsSocket(conn)
 	assert.Nil(b, err)
 

--- a/protocol/ntp/ntp_test_darwin.go
+++ b/protocol/ntp/ntp_test_darwin.go
@@ -33,7 +33,7 @@ func Test_EnableKernelTimestampsSocket(t *testing.T) {
 	connfd, err := connFd(conn)
 	assert.Nil(t, err)
 
-	// Allow reading of hardware/kernel timestamps via socket
+	// Allow reading of kernel timestamps via socket
 	err = EnableKernelTimestampsSocket(conn)
 	assert.Nil(t, err)
 

--- a/protocol/ntp/ntp_test_freebsd.go
+++ b/protocol/ntp/ntp_test_freebsd.go
@@ -33,7 +33,7 @@ func Test_EnableKernelTimestampsSocket(t *testing.T) {
 	connfd, err := connFd(conn)
 	assert.Nil(t, err)
 
-	// Allow reading of hardware/kernel timestamps via socket
+	// Allow reading of kernel timestamps via socket
 	err = EnableKernelTimestampsSocket(conn)
 	assert.Nil(t, err)
 

--- a/protocol/ntp/ntp_test_linux.go
+++ b/protocol/ntp/ntp_test_linux.go
@@ -33,16 +33,16 @@ func Test_EnableKernelTimestampsSocket(t *testing.T) {
 	connfd, err := connFd(conn)
 	assert.Nil(t, err)
 
-	// Allow reading of hardware/kernel timestamps via socket
+	// Allow reading of kernel timestamps via socket
 	err = EnableKernelTimestampsSocket(conn)
 	assert.Nil(t, err)
 
 	// Check that socket option is set
-	hwTimestampsEnabled, err := syscall.GetsockoptInt(connfd, syscall.SOL_SOCKET, syscall.SO_TIMESTAMPNS)
+	preciseKernelTimestampsEnabled, err := syscall.GetsockoptInt(connfd, syscall.SOL_SOCKET, syscall.SO_TIMESTAMPNS)
 	assert.Nil(t, err)
 	kernelTimestampsEnabled, err := syscall.GetsockoptInt(connfd, syscall.SOL_SOCKET, syscall.SO_TIMESTAMP)
 	assert.Nil(t, err)
 
 	// At least one of them should be set, which it > 0
-	assert.Greater(t, hwTimestampsEnabled+kernelTimestampsEnabled, 0, "None of the socket options is set")
+	assert.Greater(t, preciseKernelTimestampsEnabled+kernelTimestampsEnabled, 0, "None of the socket options is set")
 }

--- a/protocol/ntp/packet_darwin.go
+++ b/protocol/ntp/packet_darwin.go
@@ -23,7 +23,7 @@ import (
 	syscall "golang.org/x/sys/unix"
 )
 
-// EnableKernelTimestampsSocket enables socket options to read ether kernel timestamps
+// EnableKernelTimestampsSocket enables socket options to read kernel timestamps
 func EnableKernelTimestampsSocket(conn *net.UDPConn) error {
 	// Get socket fd
 	connfd, err := connFd(conn)
@@ -31,7 +31,7 @@ func EnableKernelTimestampsSocket(conn *net.UDPConn) error {
 		return err
 	}
 
-	// Allow reading of hardware timestamps via socket
+	// Allow reading of kernel timestamps via socket
 	if err := syscall.SetsockoptInt(connfd, syscall.SOL_SOCKET, syscall.SO_TIMESTAMP, 1); err != nil {
 		return fmt.Errorf("failed to enable SO_TIMESTAMP: %w", err)
 	}

--- a/protocol/ntp/packet_freebsd.go
+++ b/protocol/ntp/packet_freebsd.go
@@ -23,7 +23,7 @@ import (
 	syscall "golang.org/x/sys/unix"
 )
 
-// EnableKernelTimestampsSocket enables socket options to read ether kernel timestamps
+// EnableKernelTimestampsSocket enables socket options to read kernel timestamps
 func EnableKernelTimestampsSocket(conn *net.UDPConn) error {
 	// Get socket fd
 	connfd, err := connFd(conn)
@@ -31,7 +31,7 @@ func EnableKernelTimestampsSocket(conn *net.UDPConn) error {
 		return err
 	}
 
-	// Allow reading of hardware timestamps via socket
+	// Allow reading of kernel timestamps via socket
 	if err := syscall.SetsockoptInt(connfd, syscall.SOL_SOCKET, syscall.SO_TIMESTAMP, 1); err != nil {
 		return fmt.Errorf("failed to enable SO_TIMESTAMP: %w", err)
 	}

--- a/protocol/ntp/packet_linux.go
+++ b/protocol/ntp/packet_linux.go
@@ -23,7 +23,7 @@ import (
 	syscall "golang.org/x/sys/unix"
 )
 
-// EnableKernelTimestampsSocket enables socket options to read ether hardware or kernel timestamps
+// EnableKernelTimestampsSocket enables socket options to read kernel timestamps
 func EnableKernelTimestampsSocket(conn *net.UDPConn) error {
 	// Get socket fd
 	connfd, err := connFd(conn)
@@ -31,9 +31,9 @@ func EnableKernelTimestampsSocket(conn *net.UDPConn) error {
 		return err
 	}
 
-	// Allow reading of hardware timestamps via socket
+	// Allow reading of kernel timestamps via socket
 	if err := syscall.SetsockoptInt(connfd, syscall.SOL_SOCKET, syscall.SO_TIMESTAMPNS, 1); err != nil {
-		// If we can't have hardware timestamps - use kernel timestamps
+		// If we can't have kernel precise timestamps - use kernel timestamps
 		if err := syscall.SetsockoptInt(connfd, syscall.SOL_SOCKET, syscall.SO_TIMESTAMP, 1); err != nil {
 			return fmt.Errorf("failed to enable SO_TIMESTAMP: %w", err)
 		}

--- a/responder/server/server.go
+++ b/responder/server/server.go
@@ -145,21 +145,21 @@ func (s *Server) startListener(ip net.IP, port int) {
 	}
 	defer conn.Close()
 
-	// Allow reading of hardware/kernel timestamps via socket
+	// Allow reading of kernel timestamps via socket
 	if err := ntp.EnableKernelTimestampsSocket(conn); err != nil {
 		log.Fatalf("enabling timestamp error: %s", err)
 	}
 
 	for {
-		// read HW/kernel timestamp from incoming packet
-		request, nowHWtimestamp, returnaddr, err := ntp.ReadPacketWithKernelTimestamp(conn)
+		// read kernel timestamp from incoming packet
+		request, nowKernelTimestamp, returnaddr, err := ntp.ReadPacketWithKernelTimestamp(conn)
 		if err != nil {
 			log.Errorf("read packet with timestamp error: %s", err)
 			s.Stats.IncReadError()
 			continue
 		}
 		s.Stats.IncRequests()
-		s.tasks <- task{conn: conn, addr: returnaddr, received: nowHWtimestamp, request: request, stats: s.Stats}
+		s.tasks <- task{conn: conn, addr: returnaddr, received: nowKernelTimestamp, request: request, stats: s.Stats}
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
Let's not confuse people and remove hardware timestamp reference for now

## Test Plan

```
$ sudo go run github.com/facebookincubator/ntp/responder --ip 1.2.3.4 --ip 2.3.4.5 -interface lo0
WARN[0000] Creating 800 goroutine workers
WARN[0000] Starting 2 listener(s)
INFO[0000] Starting listener on 1.2.3.4:123
INFO[0000] Starting listener on 2.3.4.5:123
INFO[0000] Adding 2.3.4.5 to lo0
INFO[0000] Adding 1.2.3.4 to lo0


WARN[0013] Graceful shutdown
INFO[0013] Deleting 1.2.3.4 to lo0
INFO[0013] Deleting 2.3.4.5 to lo0
```