### PR TITLE
Improve logging levels

### DIFF
--- a/responder/server/server.go
+++ b/responder/server/server.go
@@ -55,14 +55,14 @@ type Server struct {
 
 // Start UDP server.
 func (s *Server) Start(ctx context.Context, cancelFunc context.CancelFunc) {
-	log.Warningf("Creating %d goroutine workers", s.Workers)
+	log.Infof("Creating %d goroutine workers", s.Workers)
 	s.tasks = make(chan task, s.Workers)
 	// Pre-create workers
 	for i := 0; i < s.Workers; i++ {
 		go s.startWorker()
 	}
 
-	log.Warningf("Starting %d listener(s)", len(s.ListenConfig.IPs))
+	log.Infof("Starting %d listener(s)", len(s.ListenConfig.IPs))
 
 	for _, ip := range s.ListenConfig.IPs {
 		log.Infof("Starting listener on %s:%d", ip.String(), s.ListenConfig.Port)
@@ -194,12 +194,12 @@ func (t *task) serve(response *ntp.Packet, extraoffset time.Duration) {
 		log.Debugf("Writing response: %+v", response)
 		_, err = t.conn.WriteTo(responseBytes, t.addr)
 		if err != nil {
-			log.Infof("Failed to respond to the request: %v", err)
+			log.Debugf("Failed to respond to the request: %v", err)
 		}
 		t.stats.IncResponses()
 		return
 	}
-	log.Infof("Invalid query, discarding: %v", t.request)
+	log.Debugf("Invalid query, discarding: %v", t.request)
 	t.stats.IncInvalidFormat()
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Since we set default logging level as "Info" we no longer need "Warning" hack. Additionally no more invalid query data is polluting the logs.
## Test Plan
### Before:
```
$ sudo go run github.com/facebookincubator/ntp/responder --ip 1.2.3.4 --ip 2.3.4.5 -interface lo0
WARN[0000] Creating 800 goroutine workers
WARN[0000] Starting 2 listener(s)
INFO[0000] Starting listener on 1.2.3.4:123
INFO[0000] Starting listener on 2.3.4.5:123
INFO[0000] Adding 1.2.3.4 to lo0
INFO[0000] Adding 2.3.4.5 to lo0
INFO[0020] Invalid query, discarding: &{115 102 115 100 1717832192 0 0 0 0 0 0 0 0 0 0}
^CWARN[0024] Graceful shutdown
INFO[0024] Deleting 1.2.3.4 to lo0
INFO[0024] Deleting 2.3.4.5 to lo0
```
### After
```
$ sudo go run github.com/facebookincubator/ntp/responder --ip 1.2.3.4 --ip 2.3.4.5 -interface lo0
INFO[0000] Creating 800 goroutine workers
INFO[0000] Starting 2 listener(s)
INFO[0000] Starting listener on 1.2.3.4:123
INFO[0000] Starting listener on 2.3.4.5:123
INFO[0000] Adding 1.2.3.4 to lo0
INFO[0000] Adding 2.3.4.5 to lo0
^CWARN[0011] Graceful shutdown
INFO[0011] Deleting 1.2.3.4 to lo0
INFO[0011] Deleting 2.3.4.5 to lo0
```