### PR TITLE
expose correction metric

### DIFF
--- a/ntpcheck/checker/checkresult.go
+++ b/ntpcheck/checker/checkresult.go
@@ -27,6 +27,7 @@ type NTPCheckResult struct {
 	LI          uint8
 	LIDesc      string
 	ClockSource string
+	Correction  float64
 	Event       string
 	EventCount  uint8
 	// data parsed from System Variables

--- a/ntpcheck/checker/chrony.go
+++ b/ntpcheck/checker/chrony.go
@@ -58,6 +58,7 @@ func (n *ChronyCheck) Run() (*NTPCheckResult, error) {
 	if !ok {
 		return nil, errors.Errorf("Got wrong 'tracking' response %+v", packet)
 	}
+	result.Correction = tracking.CurrentCorrection
 	result.LIDesc = control.LeapDesc[uint8(tracking.LeapStatus)]
 	result.LI = uint8(tracking.LeapStatus)
 	result.Event = "clock_sync" // no real events for chrony

--- a/ntpcheck/checker/stats.go
+++ b/ntpcheck/checker/stats.go
@@ -32,6 +32,7 @@ type NTPStats struct {
 	PeerStratum int     `json:"ntp.peer.stratum"`  // sys.peer stratum
 	Frequency   float64 `json:"ntp.sys.frequency"` // clock frequency in PPM
 	StatError   bool    `json:"ntp.stat.error"`    // error reported in Leap Status
+	Correction  float64 `json:"ntp.correction"`    // current correction
 }
 
 // NewNTPStats constructs NTPStats from NTPCheckResult
@@ -93,6 +94,7 @@ func NewNTPStats(r *NTPCheckResult) (*NTPStats, error) {
 		PeerOffset:  offset,
 		PeerStratum: stratum,
 		Frequency:   r.SysVars.Frequency,
+		Correction:  r.Correction,
 		// that's how ntpstat defines unsynchronized
 		StatError: r.LI == 3,
 	}


### PR DESCRIPTION

Example run:

```
{"ntp.peer.delay":0,"ntp.peer.poll":256,"ntp.peer.jitter":0,"ntp.peer.offset":-0.030286000765045173,"ntp.peer.stratum":2,"ntp.sys.frequency":1.6121444702148438,"ntp.stat.error":false,"ntp.correction":-0.000021913370801485144}
```