### PR TITLE
Add ntpshm lib

### DIFF
--- a/protocol/ntpshm/ntpshm.go
+++ b/protocol/ntpshm/ntpshm.go
@@ -1,0 +1,103 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ntpshm
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// SHMKEY is a key of the first NTPD SHM segment
+// http://doc.ntp.org/current-stable/drivers/driver28.html
+const SHMKEY = 0x4e545030
+
+// IPC_CREAT create if key is nonexistent
+// https://man7.org/linux/man-pages/man0/sys_ipc.h.0p.html
+const IPC_CREAT = 00001000
+
+// NTPSHMSize is a size of NTPSHM struct
+const NTPSHMSize = 96
+
+/* NTPSHM Declaration of the SHM segment from ntp (ntpd/refclock_shm.c) */
+type NTPSHM struct {
+	Mode                 int32
+	Count                int32
+	ClockTimeStampSec    int64
+	ClockTimeStampUSec   int32
+	ReceiveTimeStampSec  int64
+	ReceiveTimeStampUSec int32
+	Leap                 int32
+	Precision            int32
+	Nsamples             int32
+	Valid                int32
+	ClockTimeStampNSec   int32
+	ReceiveTimeStampNSec int32
+	Dummy                [8]int32
+}
+
+// Create a segment in SHM and return the ID
+func Create() (uintptr, error) {
+	shmID, _, errno := unix.Syscall(unix.SYS_SHMGET, uintptr(SHMKEY), 0, uintptr(IPC_CREAT|0600))
+	if errno != 0 {
+		return 0, fmt.Errorf("failed get shm: %s", unix.ErrnoName(errno))
+	}
+	return shmID, nil
+}
+
+func ptrToNTPSHM(shmptr uintptr) *NTPSHM {
+	var shm []NTPSHM
+	sh := (*reflect.SliceHeader)(unsafe.Pointer(&shm))
+	sh.Data = shmptr
+	sh.Len = 1
+	sh.Cap = 1
+
+	return &shm[0]
+}
+
+// ReadID reads SHM segment by ID
+func ReadID(id uintptr) (*NTPSHM, error) {
+	shmptr, _, errno := unix.Syscall(unix.SYS_SHMAT, id, 0, 0)
+	if errno != 0 {
+		return nil, fmt.Errorf("failed to attach to shm: %s", unix.ErrnoName(errno))
+	}
+
+	return ptrToNTPSHM(shmptr), nil
+}
+
+// Read SHM segment
+func Read() (*NTPSHM, error) {
+	shmID, _, errno := unix.Syscall(unix.SYS_SHMGET, uintptr(SHMKEY), 0, uintptr(0400))
+	if errno != 0 {
+		return nil, fmt.Errorf("failed get shm: %s", unix.ErrnoName(errno))
+	}
+
+	return ReadID(shmID)
+}
+
+// ClockTimeStamp returns the clock time
+func (n *NTPSHM) ClockTimeStamp() time.Time {
+	return time.Unix(n.ClockTimeStampSec, int64(n.ClockTimeStampNSec))
+}
+
+// ReceiveTimeStamp returns the receive time
+func (n *NTPSHM) ReceiveTimeStamp() time.Time {
+	return time.Unix(n.ReceiveTimeStampSec, int64(n.ReceiveTimeStampNSec))
+}

--- a/protocol/ntpshm/ntpshm_test.go
+++ b/protocol/ntpshm/ntpshm_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ntpshm
+
+import (
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_NTPSHMStruct(t *testing.T) {
+	testBytes := []byte{1, 0, 0, 0, 236, 72, 0, 0, 110, 133, 75, 96, 0, 0, 0, 0, 122, 156, 13, 0, 0, 0, 0, 0, 72, 133, 75, 96, 0, 0, 0, 0, 169, 250, 6, 0, 0, 0, 0, 0, 226, 255, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0, 70, 63, 43, 53, 50, 36, 67, 27, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	testNTPSHM := NTPSHM{
+		Mode:                 1,
+		Count:                18668,
+		ClockTimeStampSec:    1615562094,
+		ClockTimeStampUSec:   892026,
+		ReceiveTimeStampSec:  1615562056,
+		ReceiveTimeStampUSec: 457385,
+		Leap:                 0,
+		Precision:            -30,
+		Nsamples:             0,
+		Valid:                0,
+		ClockTimeStampNSec:   892026694,
+		ReceiveTimeStampNSec: 457385010,
+		Dummy:                [8]int32{0, 0, 0, 0, 0, 0, 0, 0},
+	}
+
+	assert.Equal(t, NTPSHMSize, int(unsafe.Sizeof(testNTPSHM)))
+
+	s := ptrToNTPSHM(uintptr(unsafe.Pointer(&testBytes[0])))
+	assert.Equal(t, testNTPSHM, *s)
+
+	assert.True(t, time.Unix(1615562056, 457385010).Equal(s.ReceiveTimeStamp()))
+	assert.True(t, time.Unix(1615562094, 892026694).Equal(s.ClockTimeStamp()))
+}
+
+func Test_NTPSHMReadID(t *testing.T) {
+	id, err := Create()
+	// Happens when we have no permissions
+	if err != nil {
+		t.SkipNow()
+	}
+	assert.NotEqual(t, 0, id)
+
+	shm, err := ReadID(id)
+	assert.Nil(t, err)
+	assert.NotNil(t, shm)
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Implement reading of NTP Shared Memory Segment (SHM0).
We don't use it for now.

## Test Plan
* Create a segment by phc2sys from PHC
```
sudo /usr/sbin/phc2sys -E ntpshm -s ens2f0 -O 37 -m -l 7
```
* Add print in the test run:
```
&{mode:1 count:20634 clockTimeStampSec:1615474428 clockTimeStampUSec:668960 receiveTimeStampSec:1615474354 receiveTimeStampUSec:670570 leap:0 precision:-30 nsamples:0 valid:1 clockTimeStampNSec:668960937 receiveTimeStampNSec:670570630 dummy:[0 0 0 0 0 0 0 0]}
```