### PR TITLE
Rename SHMTime() to Time()

### DIFF
--- a/protocol/ntpshm/ntpshm.go
+++ b/protocol/ntpshm/ntpshm.go
@@ -92,8 +92,8 @@ func Read() (*NTPSHM, error) {
 	return ReadID(shmID)
 }
 
-// SHMTime returns time from SHM
-func SHMTime() (time.Time, error) {
+// Time returns time from SHM
+func Time() (time.Time, error) {
 	shm, err := Read()
 	if err != nil {
 		return time.Time{}, err


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

On the user side it's much nicer to call ntpshm.Time() than ntpshm.SHMTime()

## Test Plan

![image](https://media.tenor.com/images/14b636b53adb4f65f99ff7d42a86672b/tenor.gif)
