### PR TITLE
leapsectz package

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Collection of Facebook's NTP libraries.
 ## Leaphash
 Utility package for computing the hash value of the official leap-second.list document
 
+## leapsectz
+Utility package for obtaining leap second information from the system timezone database
+
 ## ntpcheck
 CLI and library to perform various NTP-related tasks, including:
 * replacement for `ntptime` and `ntpdate` commands

--- a/leapsectz/leapsectz.go
+++ b/leapsectz/leapsectz.go
@@ -1,0 +1,121 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package leapsectz is a utility package for obtaining leap second
+// information from the system timezone database
+
+package leapsectz
+
+import (
+	"encoding/binary"
+	"errors"
+	"io"
+	"os"
+	"time"
+)
+
+const file = "/usr/share/zoneinfo/right/UTC"
+
+var errBadData = errors.New("malformed time zone information")
+
+// LeapSecond represents a leap second
+type LeapSecond struct {
+	Tleap uint32
+	Nleap uint32
+}
+
+// Time returns when the leap second event occurs
+func (l LeapSecond) Time() time.Time {
+	return time.Unix(int64(l.Tleap-l.Nleap+1), 0)
+}
+
+// Parse returns the list of leap seconds
+func Parse() ([]LeapSecond, error) {
+	f, err := os.Open(file)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	return parse(f)
+}
+
+func parse(r io.Reader) ([]LeapSecond, error) {
+	// 4-byte magic "TZif"
+	magic := make([]byte, 4)
+	if r.Read(magic); string(magic) != "TZif" {
+		return nil, errBadData
+	}
+
+	// 1-byte version, then 15 bytes of padding
+	p := make([]byte, 16)
+	if n, _ := r.Read(p); n != 16 {
+		return nil, errBadData
+	} else if p[0] != 0 && p[0] != '2' && p[0] != '3' {
+		return nil, errBadData
+	}
+
+	// six big-endian 32-bit integers:
+	//	number of UTC/local indicators
+	//	number of standard/wall indicators
+	//	number of leap seconds
+	//	number of transition times
+	//	number of local time zones
+	//	number of characters of time zone abbrev strings
+	const (
+		NUTCLocal = iota
+		NStdWall
+		NLeap
+		NTime
+		NZone
+		NChar
+	)
+	var n [6]int
+	for i := 0; i < 6; i++ {
+		var nn uint32
+		err := binary.Read(r, binary.BigEndian, &nn)
+		if err != nil {
+			return nil, err
+		}
+		n[i] = int(nn)
+	}
+
+	// skip uninteresting data:
+	//  tzh_timecnt (char [4])s  coded transition times a la time(2)
+	//  tzh_timecnt (unsigned char)s types of local time starting at above
+	//  tzh_typecnt repetitions of
+	//   one (char [4])  coded UT offset in seconds
+	//   one (unsigned char) used to set tm_isdst
+	//   one (unsigned char) that's an abbreviation list index
+	//  tzh_charcnt (char)s  '\0'-terminated zone abbreviations
+	skip := n[NTime]*5 + n[NZone]*6 + n[NChar]
+	data := make([]byte, skip)
+	if n, _ := r.Read(data); n != skip {
+		return nil, errBadData
+	}
+
+	var ret []LeapSecond
+	for i := 0; i < int(n[NLeap]); i++ {
+		l := LeapSecond{}
+		err := binary.Read(r, binary.BigEndian, &l)
+		if err != nil {
+			return nil, err
+		}
+		ret = append(ret, l)
+	}
+
+	return ret, nil
+}

--- a/leapsectz/leapsectz_test.go
+++ b/leapsectz/leapsectz_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leapsectz
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestParse(t *testing.T) {
+	byteData := []byte{
+		'T', 'Z', 'i', 'f',     // magic
+		'2', 0x00, 0x00, 0x00,  // version
+		0x00, 0x00, 0x00, 0x00, // pad
+		0x00, 0x00, 0x00, 0x00, // pad
+		0x00, 0x00, 0x00, 0x00, // pad
+		0x00, 0x00, 0x00, 0x00, // UTC/local
+		0x00, 0x00, 0x00, 0x00, // standard/wall
+		0x00, 0x00, 0x00, 0x01, // leap
+		0x00, 0x00, 0x00, 0x00, // transition
+		0x00, 0x00, 0x00, 0x00, // local tz
+		0x00, 0x00, 0x00, 0x00, // characters
+		0x04, 0xb2, 0x58, 0x00, // leap time
+		0x00, 0x00, 0x00, 0x01, // leap count
+	}
+
+	r := bytes.NewReader(byteData)
+
+	ls, err := parse(r)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(ls) != 1 {
+		t.Errorf("wrong leap second list length")
+	}
+
+	// Saturday, July 1, 1972 12:00:00 AM
+	if ls[0].Tleap != 78796800 {
+		t.Errorf("wrong leap second time")
+	}
+
+	if ls[0].Nleap != 1 {
+		t.Errorf("wrong leap second count")
+	}
+}

--- a/ntpcheck/cmd/utils.go
+++ b/ntpcheck/cmd/utils.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/facebookincubator/ntp/leaphash"
+	"github.com/facebookincubator/ntp/leapsectz"
 	"github.com/facebookincubator/ntp/protocol/ntp"
 	"github.com/spf13/cobra"
 )
@@ -157,6 +158,18 @@ func ntpDate(remoteServerAddr string, remoteServerPort string, requests int) err
 	return nil
 }
 
+// printLeap prints leap second information from the system timezone database
+func printLeap() error {
+	ls, err := leapsectz.Parse()
+	if err != nil {
+		return err
+	}
+	for _, l := range ls {
+		fmt.Println(l.Time().UTC())
+	}
+	return nil
+}
+
 // cli vars
 var refidIP string
 var fsCount int
@@ -181,6 +194,8 @@ func init() {
 	ntpdateCmd.Flags().StringVarP(&remoteServerAddr, "server", "s", "", "Server to query")
 	ntpdateCmd.Flags().IntVarP(&remoteServerPort, "port", "p", 123, "Port of the remote server")
 	ntpdateCmd.Flags().IntVarP(&ntpdateRequests, "requests", "r", 3, "How many requests to send")
+	// printleap
+	utilsCmd.AddCommand(printLeapCmd)
 }
 
 var utilsCmd = &cobra.Command{
@@ -233,6 +248,18 @@ var ntpdateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 		if err := ntpDate(remoteServerAddr, strconv.Itoa(remoteServerPort), ntpdateRequests); err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	},
+}
+
+var printLeapCmd = &cobra.Command{
+	Use:   "printleap",
+	Short: "Prints leap second information from the system timezone database",
+	Run: func(cmd *cobra.Command, args []string) {
+		ConfigureVerbosity()
+		if err := printLeap(); err != nil {
 			fmt.Println(err)
 			os.Exit(1)
 		}


### PR DESCRIPTION
Chrony has a `leapsectz` directive to get the next leap second info from the system tz database.

I am adding a `leapsectz` package to get visibility of the information in there.

Example run:

```
ntpchkng utils printleap
1972-07-01 00:00:00 +0000 UTC
1973-01-01 00:00:00 +0000 UTC
1974-01-01 00:00:00 +0000 UTC
1975-01-01 00:00:00 +0000 UTC
1976-01-01 00:00:00 +0000 UTC
1977-01-01 00:00:00 +0000 UTC
1978-01-01 00:00:00 +0000 UTC
1979-01-01 00:00:00 +0000 UTC
1980-01-01 00:00:00 +0000 UTC
1981-07-01 00:00:00 +0000 UTC
1982-07-01 00:00:00 +0000 UTC
1983-07-01 00:00:00 +0000 UTC
1985-07-01 00:00:00 +0000 UTC
1988-01-01 00:00:00 +0000 UTC
1990-01-01 00:00:00 +0000 UTC
1991-01-01 00:00:00 +0000 UTC
1992-07-01 00:00:00 +0000 UTC
1993-07-01 00:00:00 +0000 UTC
1994-07-01 00:00:00 +0000 UTC
1996-01-01 00:00:00 +0000 UTC
1997-07-01 00:00:00 +0000 UTC
1999-01-01 00:00:00 +0000 UTC
2006-01-01 00:00:00 +0000 UTC
2009-01-01 00:00:00 +0000 UTC
2012-07-01 00:00:00 +0000 UTC
2015-07-01 00:00:00 +0000 UTC
2017-01-01 00:00:00 +0000 UTC
```

Related code snippets:
* https://gist.github.com/zed/92df922103ac9deb1a05
* https://stackoverflow.com/questions/19332902/extract-historic-leap-seconds-from-tzdata

Go does not currently parse this data:
* https://golang.org/src/time/zoneinfo_read.go
* https://github.com/golang/go/issues/15247



