### PR TITLE
[leapsectz] lint

### DIFF
--- a/leapsectz/leapsectz.go
+++ b/leapsectz/leapsectz.go
@@ -56,7 +56,7 @@ func Parse() ([]LeapSecond, error) {
 func parse(r io.Reader) ([]LeapSecond, error) {
 	// 4-byte magic "TZif"
 	magic := make([]byte, 4)
-	if r.Read(magic); string(magic) != "TZif" {
+	if _, _ = r.Read(magic); string(magic) != "TZif" {
 		return nil, errBadData
 	}
 


### PR DESCRIPTION
Before:

```
golangci-lint run --enable deadcode --enable varcheck --enable staticcheck
leapsectz.go:59:11: Error return value of `r.Read` is not checked (errcheck)
	if r.Read(magic); string(magic) != "TZif" {
```

After:

```
golangci-lint run --enable deadcode --enable varcheck --enable staticcheck
echo $?
0
```
