### PR TITLE
[responder] remove SetPrefix and Report methods

### DIFF
--- a/responder/main.go
+++ b/responder/main.go
@@ -92,8 +92,7 @@ func main() {
 
 	// Monitoring
 	// Replace with your implementation of Stats
-	st := &stats.JSONStats{}
-	st.SetPrefix(prefix)
+	st := stats.NewJSONStats(prefix)
 	go st.Start(monitoringport)
 
 	// Replace with your implementation of Announce

--- a/responder/server/interfaces.go
+++ b/responder/server/interfaces.go
@@ -26,14 +26,6 @@ type Stats interface {
 	// Use this for passive reporters
 	Start(int)
 
-	// Report reports metrics
-	// Use this for active reporters
-	Report() error
-
-	// SetPrefix sets custom metric prefix
-	// For passive reporters this needs to be set before Start()
-	SetPrefix(prefix string)
-
 	// IncInvalidFormat atomically add 1 to the counter
 	IncInvalidFormat()
 	// IncRequests atomically add 1 to the counter

--- a/responder/server/server.go
+++ b/responder/server/server.go
@@ -79,17 +79,6 @@ func (s *Server) Start(ctx context.Context, cancelFunc context.CancelFunc) {
 		}(ip)
 	}
 
-	// Run active metric reporting.
-	go func() {
-		for {
-			<-time.After(1 * time.Minute)
-			err := s.Stats.Report()
-			if err != nil {
-				log.Errorf("[stats] %v", err)
-			}
-		}
-	}()
-
 	// Run checker periodically
 	go func() {
 		for {

--- a/responder/stats/json.go
+++ b/responder/stats/json.go
@@ -33,7 +33,6 @@ import (
 // JSONStats implements Stat interface
 // This implementation reports JSON metrics via http interface
 // This is a passive implementation. Only "Start" needs to be called
-// Report will do nothing
 type JSONStats struct {
 	// keep these aligned to 64-bit for sync/atomic
 	invalidFormat int64
@@ -45,6 +44,12 @@ type JSONStats struct {
 	announce      int64
 
 	prefix string
+}
+
+func NewJSONStats(prefix string) *JSONStats {
+	return &JSONStats{
+		prefix: prefix,
+	}
 }
 
 // toMap converts struct to a map
@@ -83,17 +88,6 @@ func (j *JSONStats) Start(port int) {
 	if err != nil {
 		log.Errorf("Failed to start listener: %v", err)
 	}
-}
-
-// SetPrefix is implementing SetPrefix function of interface
-func (j *JSONStats) SetPrefix(prefix string) {
-	j.prefix = prefix
-}
-
-// Report is implementing Report function of interface
-// As JSONStats a passive reporter, Report will do nothing
-func (j *JSONStats) Report() error {
-	return nil
 }
 
 // IncInvalidFormat atomically add 1 to the counter


### PR DESCRIPTION
Remove the `SetPrefix` and `Report` methods.

Encourage stats pulling instead of pushing.