### PR TITLE
[ntpcheck] support serverstats with chrony 4.1

### DIFF
--- a/ntpcheck/checker/serverstats.go
+++ b/ntpcheck/checker/serverstats.go
@@ -63,3 +63,11 @@ func NewServerStatsFromChrony(s *chrony.ReplyServerStats) *ServerStats {
 		PacketsDropped:  uint64(s.NTPDrops),
 	}
 }
+
+// NewServerStatsFromChrony2 constructs ServerStats from chrony ServerStats2 packet
+func NewServerStatsFromChrony2(s *chrony.ReplyServerStats2) *ServerStats {
+	return &ServerStats{
+		PacketsReceived: uint64(s.NTPHits),
+		PacketsDropped:  uint64(s.NTPDrops),
+	}
+}

--- a/protocol/chrony/client.go
+++ b/protocol/chrony/client.go
@@ -109,6 +109,16 @@ func (n *Client) Communicate(packet RequestPacket) (ResponsePacket, error) {
 			ReplyHead: *head,
 			NTPData:   *newNTPData(data),
 		}, nil
+	case rpyServerStats2:
+		data := new(ServerStats2)
+		if err = binary.Read(r, binary.BigEndian, data); err != nil {
+			return nil, err
+		}
+		log.Debugf("response data: %+v", data)
+		return &ReplyServerStats2{
+			ReplyHead:    *head,
+			ServerStats2: *data,
+		}, nil
 	default:
 		return nil, fmt.Errorf("not implemented reply type %d from %+v", head.Reply, head)
 	}

--- a/protocol/chrony/packet.go
+++ b/protocol/chrony/packet.go
@@ -63,11 +63,12 @@ const (
 
 // reply types
 const (
-	rpyNSources    ReplyType = 2
-	rpySourceData  ReplyType = 3
-	rpyTracking    ReplyType = 5
-	rpyServerStats ReplyType = 14
-	rpyNTPData     ReplyType = 16
+	rpyNSources     ReplyType = 2
+	rpySourceData   ReplyType = 3
+	rpyTracking     ReplyType = 5
+	rpyServerStats  ReplyType = 14
+	rpyNTPData      ReplyType = 16
+	rpyServerStats2 ReplyType = 22
 )
 
 // source modes
@@ -500,6 +501,24 @@ type ServerStats struct {
 type ReplyServerStats struct {
 	ReplyHead
 	ServerStats
+}
+
+// ServerStats2 contains parsed version of 'serverstats2' reply
+type ServerStats2 struct {
+	NTPHits     uint32
+	NKEHits     uint32
+	CMDHits     uint32
+	NTPDrops    uint32
+	NKEDrops    uint32
+	CMDDrops    uint32
+	LogDrops    uint32
+	NTPAuthHits uint32
+}
+
+// ReplyServerStats2 is a usable version of 'serverstats2' response
+type ReplyServerStats2 struct {
+	ReplyHead
+	ServerStats2
 }
 
 // here go request constuctors


### PR DESCRIPTION
Server stats response type and struct changed in: https://github.com/mlichvar/chrony/commit/ab54f76a38a27410ba168ea739f4575c65d4acf4

Add support for both response types.

Before:
```
ntpchkng stats
FATA[0000] failed to get 'serverstats' response: not implemented reply type 22 from &{Version:6 PKTType:2 Res1:0 Res2:0 Command:54 Reply:22 Status:0 Pad1:0 Pad2:0 Pad3:0 Sequence:3 Pad4:0 Pad5:0} 
```

After:
```
ntpchkng stats
{"ntp.peer.delay":13.619720935821533,"ntp.peer.poll":64,"ntp.peer.jitter":0.00044080343286623247,"ntp.peer.offset":0.05689799945685081,"ntp.peer.stratum":2,"ntp.sys.frequency":-13.564138412475586,"ntp.stat.error":false,"ntp.correction":9.899275843494593e-10}
```