### PR TITLE
[ntpcheck] decouple serverstats

### DIFF
--- a/ntpcheck/checker/checkresult.go
+++ b/ntpcheck/checker/checkresult.go
@@ -34,7 +34,6 @@ type NTPCheckResult struct {
 	SysVars *SystemVariables
 	// map of peers with data from PeerStatusWord and Peer Variables
 	Peers       map[uint16]*Peer
-	ServerStats *ServerStats
 	Incomplete  bool
 }
 

--- a/ntpcheck/checker/chrony_test.go
+++ b/ntpcheck/checker/chrony_test.go
@@ -107,8 +107,6 @@ func TestChronyCheck_RunDegraded(t *testing.T) {
 	prepdOutputs := []chrony.ResponsePacket{
 		// tracking
 		replyTracking,
-		// server stats
-		replyServerStats,
 		// get list of sources
 		replySources,
 		// first source
@@ -158,10 +156,6 @@ func TestChronyCheck_RunDegraded(t *testing.T) {
 				Flashers:   []string{},
 			},
 		},
-		ServerStats: &ServerStats{
-			PacketsReceived: 1234,
-			PacketsDropped:  5678,
-		},
 	}
 
 	check := &ChronyCheck{
@@ -177,8 +171,6 @@ func TestChronyCheck_Run(t *testing.T) {
 	prepdOutputs := []chrony.ResponsePacket{
 		// tracking
 		replyTracking,
-		// server stats
-		replyServerStats,
 		// get list of sources
 		replySources,
 		// first source
@@ -234,10 +226,6 @@ func TestChronyCheck_Run(t *testing.T) {
 				Flashers:   []string{},
 			},
 		},
-		ServerStats: &ServerStats{
-			PacketsReceived: 1234,
-			PacketsDropped:  5678,
-		},
 	}
 
 	check := &ChronyCheck{
@@ -245,6 +233,26 @@ func TestChronyCheck_Run(t *testing.T) {
 	}
 
 	got, err := check.Run()
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestChronyCheck_ServerStats(t *testing.T) {
+	prepdOutputs := []chrony.ResponsePacket{
+		// server stats
+		replyServerStats,
+	}
+
+	want := &ServerStats{
+		PacketsReceived: 1234,
+		PacketsDropped:  5678,
+	}
+
+	check := &ChronyCheck{
+		Client: &fakeChronyClient{readCount: 0, outputs: prepdOutputs},
+	}
+
+	got, err := check.ServerStats()
 	require.NoError(t, err)
 	require.Equal(t, want, got)
 }

--- a/ntpcheck/cmd/serverstats.go
+++ b/ntpcheck/cmd/serverstats.go
@@ -26,11 +26,8 @@ import (
 	"github.com/facebookincubator/ntp/ntpcheck/checker"
 )
 
-func printServerStats(r *checker.NTPCheckResult) error {
-	if r.ServerStats == nil {
-		return fmt.Errorf("no server stats present (chrony is supported only over unix socket, required ntpd version 4.2.8+)")
-	}
-	toPrint, err := json.Marshal(r.ServerStats)
+func printServerStats(r *checker.ServerStats) error {
+	toPrint, err := json.Marshal(r)
 	if err != nil {
 		return err
 	}
@@ -49,7 +46,7 @@ var serverStatsCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ConfigureVerbosity()
 
-		result, err := checker.RunCheck(server)
+		result, err := checker.RunServerStats(server)
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
* Remove logic to automatically choose between UDP or unix socket connection for Chrony
* Decouple ServerStats from the main Check function
* Use unix socket only for the ServerStats
* Use UDP for everything else