### PR TITLE
[ntpcheck] remove ntpdata

### DIFF
--- a/ntpcheck/checker/checkresult.go
+++ b/ntpcheck/checker/checkresult.go
@@ -34,7 +34,6 @@ type NTPCheckResult struct {
 	SysVars *SystemVariables
 	// map of peers with data from PeerStatusWord and Peer Variables
 	Peers       map[uint16]*Peer
-	Incomplete  bool
 }
 
 // FindSysPeer returns sys.peer (main source of NTP information for server)

--- a/ntpcheck/checker/chrony.go
+++ b/ntpcheck/checker/chrony.go
@@ -125,25 +125,7 @@ func (n *ChronyCheck) Run() (*NTPCheckResult, error) {
 		if !ok {
 			return nil, errors.Errorf("Got wrong 'sourcedata' response %+v", packet)
 		}
-		// try to get ntpdata, which is available only through socket
-		var ntpData *chrony.ReplyNTPData
-		if sourceData.Mode != chrony.SourceModeRef {
-			ntpDataReq := chrony.NewNTPDataPacket(sourceData.IPAddr)
-			packet, err = n.Client.Communicate(ntpDataReq)
-			if err == nil {
-				ntpData, ok = packet.(*chrony.ReplyNTPData)
-				if !ok {
-					return nil, errors.Errorf("Got wrong 'ntpdata' response %+v", packet)
-				}
-			} else if err != chrony.ErrNotAuthorized {
-				return nil, errors.Wrapf(err, "failed to get 'ntpdata' response for source #%d", i)
-			}
-			// unauthorized when asked for ntp data
-			if ntpData == nil {
-				result.Incomplete = true
-			}
-		}
-		peer, err := NewPeerFromChrony(sourceData, ntpData)
+		peer, err := NewPeerFromChrony(sourceData)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to create Peer structure from response packet for peer=%s", sourceData.IPAddr)
 		}

--- a/ntpcheck/checker/peer.go
+++ b/ntpcheck/checker/peer.go
@@ -172,7 +172,7 @@ var chronyToPeerSelection = map[chrony.SourceStateType]uint8{
 }
 
 // NewPeerFromChrony constructs Peer from two chrony packets
-func NewPeerFromChrony(s *chrony.ReplySourceData, p *chrony.ReplyNTPData) (*Peer, error) {
+func NewPeerFromChrony(s *chrony.ReplySourceData) (*Peer, error) {
 	if s == nil {
 		return nil, fmt.Errorf("no ReplySourceData to create Peer")
 	}
@@ -199,31 +199,6 @@ func NewPeerFromChrony(s *chrony.ReplySourceData, p *chrony.ReplyNTPData) (*Peer
 		Stratum:      int(s.Stratum),
 		SRCAdr:       s.IPAddr.String(),
 		Reach:        uint8(s.Reachability),
-	}
-	// populate data from ntpdata struct
-	if p != nil {
-		refID := chrony.RefidAsHEX(p.RefID)
-		// Only stratum 1 servers can have GPS or something else as string refID
-		if p.Stratum == 1 {
-			refIDStr := chrony.RefidToString(p.RefID)
-			if len(refIDStr) > 0 {
-				refID = refIDStr
-			}
-		}
-		peer.Leap = int(p.Leap)
-		peer.HPoll = int(p.Poll)
-		peer.DSTAdr = p.LocalAddr.String()
-		peer.RefTime = p.RefTime.String()
-		peer.Offset = secToMS(p.Offset)
-		peer.Dispersion = secToMS(p.PeerDispersion)
-		peer.DSTPort = int(p.RemotePort)
-		peer.RefID = refID
-		peer.PPoll = int(p.Poll)
-		peer.Jitter = secToMS(p.PeerDispersion) // best approx we have
-		peer.RootDelay = secToMS(p.RootDelay)
-		peer.Precision = int(p.Precision)
-		peer.Delay = secToMS(p.PeerDelay)
-		peer.RootDisp = secToMS(p.RootDispersion)
 	}
 	// no need for sanity check as we are not parsing k=v pairs in case of chrony proto
 	return &peer, nil

--- a/ntpcheck/checker/peer_test.go
+++ b/ntpcheck/checker/peer_test.go
@@ -18,7 +18,6 @@ package checker
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -106,47 +105,21 @@ func TestNewPeerFromChrony(t *testing.T) {
 	sourceData.State = chrony.SourceStateCandidate
 	sourceData.Flags = chrony.NTPFlagsTests
 
-	ntpData := &chrony.ReplyNTPData{}
-	ntpData.Poll = 10
-	ntpData.RefID = 123456
-	ntpData.RefTime = time.Unix(1587738257, 0)
 	tests := []struct {
 		name    string
 		s       *chrony.ReplySourceData
-		p       *chrony.ReplyNTPData
 		want    *Peer
 		wantErr bool
 	}{
 		{
 			name:    "no data",
 			s:       nil,
-			p:       nil,
 			want:    nil,
 			wantErr: true,
 		},
 		{
-			name: "fallback, no ReplyNTPData",
-			s:    sourceData,
-			p:    nil,
-			want: &Peer{
-				Stratum:    3,
-				Offset:     -0,
-				HPoll:      10,
-				PPoll:      10,
-				Flashers:   []string{},
-				Configured: true,
-				Reachable:  true,
-				Selection:  control.SelCandidate,
-				Condition:  control.PeerSelect[control.SelCandidate],
-				Reach:      255,
-				SRCAdr:     "<nil>",
-			},
-			wantErr: false,
-		},
-		{
 			name: "full data",
 			s:    sourceData,
-			p:    ntpData,
 			want: &Peer{
 				Stratum:    3,
 				Offset:     -0,
@@ -159,16 +132,13 @@ func TestNewPeerFromChrony(t *testing.T) {
 				Condition:  control.PeerSelect[control.SelCandidate],
 				Reach:      255,
 				SRCAdr:     "<nil>",
-				DSTAdr:     "<nil>",
-				RefID:      "0001E240",
-				RefTime:    ntpData.RefTime.String(),
 			},
 			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := NewPeerFromChrony(tt.s, tt.p)
+			got, err := NewPeerFromChrony(tt.s)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewPeerFromChrony() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/protocol/chrony/client.go
+++ b/protocol/chrony/client.go
@@ -52,9 +52,6 @@ func (n *Client) Communicate(packet RequestPacket) (ResponsePacket, error) {
 		return nil, err
 	}
 	log.Debugf("response head: %+v", head)
-	if head.Status == sttUnauth {
-		return nil, ErrNotAuthorized
-	}
 	if head.Status != sttSuccess {
 		return nil, fmt.Errorf("got status %s", StatusDesc[head.Status])
 	}
@@ -98,16 +95,6 @@ func (n *Client) Communicate(packet RequestPacket) (ResponsePacket, error) {
 		return &ReplyServerStats{
 			ReplyHead:   *head,
 			ServerStats: *data,
-		}, nil
-	case rpyNTPData:
-		data := new(replyNTPDataContent)
-		if err = binary.Read(r, binary.BigEndian, data); err != nil {
-			return nil, err
-		}
-		log.Debugf("response data: %+v", data)
-		return &ReplyNTPData{
-			ReplyHead: *head,
-			NTPData:   *newNTPData(data),
 		}, nil
 	case rpyServerStats2:
 		data := new(ServerStats2)

--- a/protocol/chrony/client_test.go
+++ b/protocol/chrony/client_test.go
@@ -94,37 +94,6 @@ func TestCommunicateError(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestCommunicateAuthError(t *testing.T) {
-	var err error
-	buf := &bytes.Buffer{}
-	packetHead := ReplyHead{
-		Version:  protoVersionNumber,
-		PKTType:  pktTypeCmdReply,
-		Res1:     0,
-		Res2:     0,
-		Command:  reqTracking,
-		Reply:    rpyTracking,
-		Status:   sttUnauth,
-		Pad1:     0,
-		Pad2:     0,
-		Pad3:     0,
-		Sequence: 2,
-		Pad4:     0,
-		Pad5:     0,
-	}
-	packetBody := replyTrackingContent{}
-	err = binary.Write(buf, binary.BigEndian, packetHead)
-	require.NoError(t, err)
-	err = binary.Write(buf, binary.BigEndian, packetBody)
-	require.NoError(t, err)
-	conn := newConn([]*bytes.Buffer{
-		buf,
-	})
-	client := Client{Sequence: 1, Connection: conn}
-	_, err = client.Communicate(NewTrackingPacket())
-	require.Equal(t, ErrNotAuthorized, err)
-}
-
 // Test if we can read reply properly
 func TestCommunicateOK(t *testing.T) {
 	var err error

--- a/protocol/chrony/helpers.go
+++ b/protocol/chrony/helpers.go
@@ -17,17 +17,12 @@ limitations under the License.
 package chrony
 
 import (
-	"errors"
 	"fmt"
 	"math"
 	"net"
 	"time"
 	"unicode"
 )
-
-// ErrNotAuthorized identifies failure to get data from Chronyd when we are not authorized to do so
-// (like asking for NTP data over UDP instead of unix socket)
-var ErrNotAuthorized = errors.New("Not authorized")
 
 // ChronySocketPath is the default path to chronyd socket
 const ChronySocketPath = "/var/run/chrony/chronyd.sock"

--- a/protocol/chrony/packet.go
+++ b/protocol/chrony/packet.go
@@ -58,7 +58,6 @@ const (
 	reqSourceData  CommandType = 15
 	reqTracking    CommandType = 33
 	reqServerStats CommandType = 54
-	reqNTPData     CommandType = 57
 )
 
 // reply types
@@ -67,7 +66,6 @@ const (
 	rpySourceData   ReplyType = 3
 	rpyTracking     ReplyType = 5
 	rpyServerStats  ReplyType = 14
-	rpyNTPData      ReplyType = 16
 	rpyServerStats2 ReplyType = 22
 )
 
@@ -396,98 +394,6 @@ type ReplyTracking struct {
 	Tracking
 }
 
-type replyNTPDataContent struct {
-	RemoteAddr      ipAddr
-	LocalAddr       ipAddr
-	RemotePort      uint16
-	Leap            uint8
-	Version         uint8
-	Mode            uint8
-	Stratum         uint8
-	Poll            int8
-	Precision       int8
-	RootDelay       chronyFloat
-	RootDispersion  chronyFloat
-	RefID           uint32
-	RefTime         timeSpec
-	Offset          chronyFloat
-	PeerDelay       chronyFloat
-	PeerDispersion  chronyFloat
-	ResponseTime    chronyFloat
-	JitterAsymmetry chronyFloat
-	Flags           uint16
-	TXTssChar       uint8
-	RXTssChar       uint8
-	TotalTXCount    uint32
-	TotalRXCount    uint32
-	TotalValidCount uint32
-	Reserved        [4]uint32
-	EOR             int32
-}
-
-// NTPData contains parsed version of 'ntpdata' reply
-type NTPData struct {
-	RemoteAddr      net.IP
-	LocalAddr       net.IP
-	RemotePort      uint16
-	Leap            uint8
-	Version         uint8
-	Mode            uint8
-	Stratum         uint8
-	Poll            int8
-	Precision       int8
-	RootDelay       float64
-	RootDispersion  float64
-	RefID           uint32
-	RefTime         time.Time
-	Offset          float64
-	PeerDelay       float64
-	PeerDispersion  float64
-	ResponseTime    float64
-	JitterAsymmetry float64
-	Flags           uint16
-	TXTssChar       uint8
-	RXTssChar       uint8
-	TotalTXCount    uint32
-	TotalRXCount    uint32
-	TotalValidCount uint32
-}
-
-func newNTPData(r *replyNTPDataContent) *NTPData {
-	return &NTPData{
-		RemoteAddr:      r.RemoteAddr.ToNetIP(),
-		LocalAddr:       r.LocalAddr.ToNetIP(),
-		RemotePort:      r.RemotePort,
-		Leap:            r.Leap,
-		Version:         r.Version,
-		Mode:            r.Mode,
-		Stratum:         r.Stratum,
-		Poll:            r.Poll,
-		Precision:       r.Precision,
-		RootDelay:       r.RootDelay.ToFloat(),
-		RootDispersion:  r.RootDispersion.ToFloat(),
-		RefID:           r.RefID,
-		RefTime:         r.RefTime.ToTime(),
-		Offset:          r.Offset.ToFloat(),
-		PeerDelay:       r.PeerDelay.ToFloat(),
-		PeerDispersion:  r.PeerDispersion.ToFloat(),
-		ResponseTime:    r.ResponseTime.ToFloat(),
-		JitterAsymmetry: r.JitterAsymmetry.ToFloat(),
-		Flags:           r.Flags,
-		TXTssChar:       r.TXTssChar,
-		RXTssChar:       r.RXTssChar,
-		TotalTXCount:    r.TotalTXCount,
-		TotalRXCount:    r.TotalRXCount,
-		TotalValidCount: r.TotalValidCount,
-	}
-}
-
-// ReplyNTPData is a what end user will get for of 'ntp data' response
-type ReplyNTPData struct {
-	ReplyHead
-	NTPData
-}
-
 // ServerStats contains parsed version of 'serverstats' reply
 type ServerStats struct {
 	NTPHits  uint32
@@ -554,18 +460,6 @@ func NewSourceDataPacket(sourceID int32) *RequestSourceData {
 			Command: reqSourceData,
 		},
 		Index: sourceID,
-	}
-}
-
-// NewNTPDataPacket creates new packet to request 'ntp data' information for given peer IP
-func NewNTPDataPacket(ip net.IP) *RequestNTPData {
-	return &RequestNTPData{
-		RequestHead: RequestHead{
-			Version: protoVersionNumber,
-			PKTType: pktTypeCmdRequest,
-			Command: reqNTPData,
-		},
-		IPAddr: *newIPAddr(ip),
 	}
 }
 


### PR DESCRIPTION
* Remove `ntpdata`, which is part of the private subset of the protocol, to avoid future breakage
* This was mainly used to get the `jitter` but we don't deeply need this