### PR TITLE
[ntpcheck] decouple ntpdata

### DIFF
--- a/ntpcheck/checker/checkresult.go
+++ b/ntpcheck/checker/checkresult.go
@@ -33,8 +33,7 @@ type NTPCheckResult struct {
 	// data parsed from System Variables
 	SysVars *SystemVariables
 	// map of peers with data from PeerStatusWord and Peer Variables
-	Peers       map[uint16]*Peer
-	Incomplete  bool
+	Peers map[uint16]*Peer
 }
 
 // FindSysPeer returns sys.peer (main source of NTP information for server)

--- a/protocol/chrony/client.go
+++ b/protocol/chrony/client.go
@@ -52,9 +52,6 @@ func (n *Client) Communicate(packet RequestPacket) (ResponsePacket, error) {
 		return nil, err
 	}
 	log.Debugf("response head: %+v", head)
-	if head.Status == sttUnauth {
-		return nil, ErrNotAuthorized
-	}
 	if head.Status != sttSuccess {
 		return nil, fmt.Errorf("got status %s", StatusDesc[head.Status])
 	}

--- a/protocol/chrony/client_test.go
+++ b/protocol/chrony/client_test.go
@@ -94,37 +94,6 @@ func TestCommunicateError(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestCommunicateAuthError(t *testing.T) {
-	var err error
-	buf := &bytes.Buffer{}
-	packetHead := ReplyHead{
-		Version:  protoVersionNumber,
-		PKTType:  pktTypeCmdReply,
-		Res1:     0,
-		Res2:     0,
-		Command:  reqTracking,
-		Reply:    rpyTracking,
-		Status:   sttUnauth,
-		Pad1:     0,
-		Pad2:     0,
-		Pad3:     0,
-		Sequence: 2,
-		Pad4:     0,
-		Pad5:     0,
-	}
-	packetBody := replyTrackingContent{}
-	err = binary.Write(buf, binary.BigEndian, packetHead)
-	require.NoError(t, err)
-	err = binary.Write(buf, binary.BigEndian, packetBody)
-	require.NoError(t, err)
-	conn := newConn([]*bytes.Buffer{
-		buf,
-	})
-	client := Client{Sequence: 1, Connection: conn}
-	_, err = client.Communicate(NewTrackingPacket())
-	require.Equal(t, ErrNotAuthorized, err)
-}
-
 // Test if we can read reply properly
 func TestCommunicateOK(t *testing.T) {
 	var err error

--- a/protocol/chrony/helpers.go
+++ b/protocol/chrony/helpers.go
@@ -17,17 +17,12 @@ limitations under the License.
 package chrony
 
 import (
-	"errors"
 	"fmt"
 	"math"
 	"net"
 	"time"
 	"unicode"
 )
-
-// ErrNotAuthorized identifies failure to get data from Chronyd when we are not authorized to do so
-// (like asking for NTP data over UDP instead of unix socket)
-var ErrNotAuthorized = errors.New("Not authorized")
 
 // ChronySocketPath is the default path to chronyd socket
 const ChronySocketPath = "/var/run/chrony/chronyd.sock"


### PR DESCRIPTION
* Remove the `Incomplete` field from the `NTPCheckResult`struct
* Remove the fallback logic to have more control of what data is going to be gathered
* Add `RunNTPData` to explicitly use the unix socket and private protocol