### PR TITLE
protocol/chrony: support 'sourcestats' query

### DIFF
--- a/protocol/chrony/client.go
+++ b/protocol/chrony/client.go
@@ -86,6 +86,16 @@ func (n *Client) Communicate(packet RequestPacket) (ResponsePacket, error) {
 			ReplyHead: *head,
 			Tracking:  *newTracking(data),
 		}, nil
+	case rpySourceStats:
+		data := new(replySourceStatsContent)
+		if err = binary.Read(r, binary.BigEndian, data); err != nil {
+			return nil, err
+		}
+		log.Debugf("response data: %+v", data)
+		return &ReplySourceStats{
+			ReplyHead:   *head,
+			SourceStats: *newSourceStats(data),
+		}, nil
 	case rpyServerStats:
 		data := new(ServerStats)
 		if err = binary.Read(r, binary.BigEndian, data); err != nil {


### PR DESCRIPTION
> Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

There are only two fields, but ;)

## Summary

> Explain the **motivation** for making this change. What existing problem does the pull request solve?

Chrony puts some source information into the "SourceData" reply, which the library already handles, and some additional information into the "SourceStats" reply, which this PR adds.  I needed the stats to keep track of how far off 1Hz various PPS sources are (the "ResidFreqPPM" element).

## Test Plan

> Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc.

I was hoping there would be some test infrastructure in the repo to properly test new messages, but the current state is that most messages aren't tested.  I could be persuaded to take some packet captures and check that they unmarshal into the right fields.  Or I could just submit this and it could be someone else's problem in the future.

In terms of manually testing, we can compare the output of this codepath with `chronyc sourcestats` on two machines:

### Machine A

`chronyc (chrony) version 4.0 (+READLINE +SECHASH +IPV6 -DEBUG)`

`chronyd (chrony) version 4.0 (+CMDMON +NTP +REFCLOCK +RTC +PRIVDROP +SCFILTER +SIGND +ASYNCDNS +NTS +SECHASH +IPV6 -DEBUG)`

This code (+ https://github.com/jrockway/beaglebone-gps-clock to produce the output):

```
Name/IP Address              NP  NR           Span  Frequency  Freq Skew        Offset       Std Dev
====================================================================================================
PHC0                         46  26           6m0s    +22.704      0.004  1.741635322s         788ns
45.15.168.198                 9   6       2h17m48s     +0.126      0.334   -1.177994ms      492.01µs
216.229.0.50                 10   6       2h35m11s     +0.484      0.657    4.741208ms    1.306933ms
12.167.151.1                 12   7        3h9m24s     +0.383      0.836       26.66µs    2.176271ms
162.159.200.1                12   8        3h9m15s     +0.125      0.725    -2.80691ms    2.154848ms
192.168.1.62                 64  30           1m4s     +0.004      0.740            0s      32.452µs
```

`chronyc sourcestats` (the samples were taken a few seconds apart, so the numbers don't match perfectly, but it does feel like the right field is going to the right place):

```
Name/IP Address            NP  NR  Span  Frequency  Freq Skew  Offset  Std Dev
==============================================================================
PHC0                       47  26   368    +22.694      0.004  +1742ms   780ns
45.15.168.198               9   6  137m     +0.116      0.334  -1179us   492us
nu.binary.net              10   6  155m     +0.474      0.657  +4742us  1307us
12.167.151.1               12   7  189m     +0.372      0.836    +27us  2176us
time.cloudflare.com        12   8  189m     +0.114      0.725  -2808us  2155us
192.168.1.62               49  25    49     +0.029      1.110     +9ns    31us
```

### Machine B

`chronyc (chrony) version 3.4 (+READLINE +SECHASH +IPV6 -DEBUG)`

`chronyd (chrony) version 3.4 (+CMDMON +NTP +REFCLOCK +RTC +PRIVDROP +SCFILTER +SIGND +ASYNCDNS +SECHASH +IPV6 -DEBUG)`

This code:

```
Name/IP Address              NP  NR           Span  Frequency  Freq Skew        Offset       Std Dev
====================================================================================================
GPS                          31  16           8m2s    +20.126     14.265   12.809642ms    3.673112ms
PPS                          16   9           4m0s     +0.000      0.016            0s       1.113µs
RTC                          10   8          2m22s     -0.036      0.011     385.133µs         304ns
180.77.60.117                50  32      14h21m50s     +0.230      0.099    4.737684ms    3.096571ms
101.187.24.205               26  14       7h10m38s     +0.257      0.304   -5.456276ms     2.95475ms
38.229.52.9                  51  24       14h40m5s     +0.190      0.085   -9.521911ms    2.579329ms
162.159.200.1                30  14       8h18m54s     +0.236      0.201   -3.028984ms    2.633467ms
```

`chronyc sourcestats`:

```
Name/IP Address            NP  NR  Span  Frequency  Freq Skew  Offset  Std Dev
==============================================================================
GPS                        31  16   482    +20.126     14.265    +13ms  3673us
PPS                        16   9   240     +0.000      0.016     +0ns  1113ns
RTC                        10   8   142     -0.036      0.011   +385us   304ns
2602:fe90:300:1a2::a093:>  50  32   14h     +0.230      0.099  +4738us  3097us
2605:6400:d814::ad18       26  14  430m     +0.257      0.304  -5456us  2955us
38.229.52.9                51  24   14h     +0.190      0.085  -9522us  2579us
time.cloudflare.com        30  14  498m     +0.236      0.201  -3029us  2633us
```

These are pretty much identical, modulo my inability to write out the proper IPv6 address from the refid ;)