### PR TITLE
Adding check correction metric to ntpcheck diag

### DIFF
--- a/ntpcheck/cmd/diag.go
+++ b/ntpcheck/cmd/diag.go
@@ -21,6 +21,7 @@ import (
 	"math"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/facebookincubator/ntp/ntpcheck/checker"
 	"github.com/fatih/color"
@@ -122,6 +123,19 @@ func checkJitter(r *checker.NTPCheckResult) (status, string) {
 	)
 }
 
+func checkCorrectionMetric(r *checker.NTPCheckResult) (status, string) {
+	const warnThreshold time.Duration = time.Minute
+	const failThreshold time.Duration = 10 * time.Minute
+	var correctionInMilliseconds = r.Correction * 1000.0
+	return checkAgainstThreshold(
+		"Current correction",
+		correctionInMilliseconds,
+		float64(warnThreshold.Milliseconds()),
+		float64(failThreshold.Milliseconds()),
+		"Correction is the difference between system time and chronyd’s estimate of the current true time.",
+	)
+}
+
 func checkOffset(r *checker.NTPCheckResult) (status, string) {
 	syspeer, err := r.FindSysPeer()
 	if err != nil {
@@ -192,6 +206,7 @@ var diagnosers = []diagnoser{
 	checkLeap,
 	checkOffset,
 	checkJitter,
+	checkCorrectionMetric,
 	checkPeersFlash,
 	checkPeersReach,
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Exposing pre existing correction field to diag results

Warning Threshold: 1 minute
Error Threshold: 10 minutes

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

`./ntp/ntpcheck/ntpcheck/ntpcheck/ntpcheck diag`

NOTE: I ran 3 times and manually adjusted correction to get different cases

```
[ OK ] Leap indicator is set to 'none'
[ OK ] Sys Peer offset is 0.007ms, we expect it to be within 1.0ms
[ OK ] Sys Peer jitter is 0.000ms, we expect it to be within 1.0ms
[ OK ] Current correction is 0.003ms, we expect it to be within 60000.0ms
[ OK ] All 18 peers are OK (have 'flash' indicator set to 0)
[ OK ] All 18 peers were reachable 8/8 last sync attempts
```
```
[ OK ] Leap indicator is set to 'none'
[ OK ] Sys Peer offset is 0.007ms, we expect it to be within 1.0ms
[ OK ] Sys Peer jitter is 0.000ms, we expect it to be within 1.0ms
[WARN] Current correction is 70000.003ms, we expect it to be within 60000.0ms. Correction is the difference between system time and chronyd’s estimate of the current true time.
[ OK ] All 18 peers are OK (have 'flash' indicator set to 0)
[ OK ] All 18 peers were reachable 8/8 last sync attempts
```
```
[ OK ] Leap indicator is set to 'none'
[ OK ] Sys Peer offset is 0.007ms, we expect it to be within 1.0ms
[ OK ] Sys Peer jitter is 0.000ms, we expect it to be within 1.0ms
[FAIL] Current correction is 610000.003ms, we expect it to be within 60000.0ms. Correction is the difference between system time and chronyd’s estimate of the current true time.
[ OK ] All 18 peers are OK (have 'flash' indicator set to 0)
[ OK ] All 18 peers were reachable 8/8 last sync attempts
```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, copy text from console etc. -->
